### PR TITLE
Made bingo compatible with 1.10

### DIFF
--- a/BingoMode/BingoChallenges/BingoAchievementChallenge.cs
+++ b/BingoMode/BingoChallenges/BingoAchievementChallenge.cs
@@ -147,14 +147,14 @@ namespace BingoMode.BingoChallenges
         public override void AddHooks()
         {
             //IL.WinState.CycleCompleted += WinState_CycleCompleted;
-            On.Menu.KarmaLadder.ctor += KarmaLadder_ctor;
+            On.Menu.KarmaLadder.ctor_Menu_MenuObject_Vector2_HUD_IntVector2_bool += KarmaLadder_ctor;
         }
 
         public override void RemoveHooks()
         {
 
             //IL.WinState.CycleCompleted -= WinState_CycleCompleted;
-            On.Menu.KarmaLadder.ctor -= KarmaLadder_ctor;
+            On.Menu.KarmaLadder.ctor_Menu_MenuObject_Vector2_HUD_IntVector2_bool -= KarmaLadder_ctor;
         }
 
         public override List<object> Settings() => [ID];

--- a/BingoMode/BingoChallenges/BingoKillChallenge.cs
+++ b/BingoMode/BingoChallenges/BingoKillChallenge.cs
@@ -125,7 +125,7 @@ namespace BingoMode.BingoChallenges
                 expeditionCreature.creature == CreatureType.Centiwing ||
                 expeditionCreature.creature == CreatureType.SmallCentipede ||
                 expeditionCreature.creature == CreatureType.RedCentipede ||
-                expeditionCreature.creature == MoreSlugcatsEnums.CreatureTemplateType.AquaCenti) && UnityEngine.Random.value < 0.3f) weapo = "PuffBall";
+                expeditionCreature.creature == DLCSharedEnums.CreatureTemplateType.AquaCenti) && UnityEngine.Random.value < 0.3f) weapo = "PuffBall";
             return new BingoKillChallenge
             {
                 crit = new(doCreature ? expeditionCreature.creature.value : "Any Creature", "Creature Type", 0, listName: "creatures"),

--- a/BingoMode/BingoChallenges/ChallengeHooks.cs
+++ b/BingoMode/BingoChallenges/ChallengeHooks.cs
@@ -15,6 +15,7 @@ using UnityEngine;
 using CreatureType = CreatureTemplate.Type;
 using ItemType = AbstractPhysicalObject.AbstractObjectType;
 using MSCItemType = MoreSlugcats.MoreSlugcatsEnums.AbstractObjectType;
+using DLCItemType = DLCSharedEnums.AbstractObjectType;
 
 namespace BingoMode.BingoChallenges
 {
@@ -195,9 +196,9 @@ namespace BingoMode.BingoChallenges
             }
         }
 
-        public static void Room_ctor(On.Room.orig_ctor orig, Room self, RainWorldGame game, World world, AbstractRoom abstractRoom)
+        public static void Room_ctor(On.Room.orig_ctor orig, Room self, RainWorldGame game, World world, AbstractRoom abstractRoom, bool devUI)
         {
-            orig.Invoke(self, game, world, abstractRoom);
+            orig.Invoke(self, game, world, abstractRoom, devUI);
 
             if (!abstractRoom.scavengerTrader) return;
 
@@ -211,7 +212,7 @@ namespace BingoMode.BingoChallenges
             }
         }
 
-        public static void KarmaLadder_ctor(On.Menu.KarmaLadder.orig_ctor orig, KarmaLadder self, Menu.Menu menu, MenuObject owner, Vector2 pos, HUD.HUD hud, IntVector2 displayKarma, bool reinforced)
+        public static void KarmaLadder_ctor(On.Menu.KarmaLadder.orig_ctor_Menu_MenuObject_Vector2_HUD_IntVector2_bool orig, KarmaLadder self, Menu.Menu menu, MenuObject owner, Vector2 pos, HUD.HUD hud, IntVector2 displayKarma, bool reinforced)
         {
             orig.Invoke(self, menu, owner, pos, hud, displayKarma, reinforced);
 
@@ -377,7 +378,7 @@ namespace BingoMode.BingoChallenges
                 x => x.MatchLdfld<AbstractSpear>("needle")
                 ))
             {
-                c.Emit(OpCodes.Ldloc, 8);
+                c.Emit(OpCodes.Ldloc, 10);
                 c.EmitDelegate<Func<bool, AbstractSpear, bool>>((orig, spear) =>
                 {
                     if (ExpeditionData.challengeList.Any(x => x is BingoTradeTradedChallenge c && c.traderItems.Keys.Count > 0 && c.traderItems.Keys.Contains(spear.ID)))
@@ -535,7 +536,7 @@ namespace BingoMode.BingoChallenges
                 ))
             {
                 b.Emit(OpCodes.Ldarg_0);
-                b.Emit(OpCodes.Ldloc, 72);
+                b.Emit(OpCodes.Ldloc, 144);
                 b.EmitDelegate<Action<Room, WorldCoordinate>>((room, pos) =>
                 {
                     AbstractWorldEntity existingFucker = room.abstractRoom.entities.FirstOrDefault(x => x is AbstractPhysicalObject o && o.type == MSCItemType.EnergyCell);
@@ -1181,7 +1182,7 @@ namespace BingoMode.BingoChallenges
             ILCursor c = new(il);
 
             if (c.TryGotoNext(
-                x => x.MatchLdsfld<ModManager>("MSC")
+                x => x.MatchCallOrCallvirt<ModManager>("get_DLCShared")
                 ))
             {
                 c.Emit(OpCodes.Ldarg_1);
@@ -1485,7 +1486,7 @@ namespace BingoMode.BingoChallenges
                 ))
             {
                 c.Emit(OpCodes.Ldarg_0);
-                c.Emit(OpCodes.Ldloc, 23);
+                c.Emit(OpCodes.Ldloc, 27);
                 c.EmitDelegate<Func<bool, Room, int, bool>>((orig, self, i) =>
                 {
                     if (self.roomSettings.placedObjects[i].data is CollectToken.CollectTokenData c && BingoData.challengeTokens.Contains(c.tokenString + (c.isRed ? "-safari" : ""))) orig = false;
@@ -1506,7 +1507,7 @@ namespace BingoMode.BingoChallenges
                 ))
             {
                 b.Emit(OpCodes.Ldarg_0);
-                b.Emit(OpCodes.Ldloc, 72);
+                b.Emit(OpCodes.Ldloc, 140);
                 b.EmitDelegate<Action<Room, WorldCoordinate>>((room, pos) =>
                 {
                     AbstractWorldEntity existingFucker = room.abstractRoom.entities.FirstOrDefault(x => x is AbstractPhysicalObject o && o.type == ItemType.NSHSwarmer);
@@ -1527,13 +1528,13 @@ namespace BingoMode.BingoChallenges
         {
             ILCursor c = new(il);
             if (c.TryGotoNext(MoveType.After,
-                x => x.MatchLdloc(43), // 3696
+                x => x.MatchLdloc(95), // 4fa1
                 x => x.MatchCallOrCallvirt(typeof(List<PlacedObject>).GetMethod("get_Item")),
                 x => x.MatchLdfld<PlacedObject>("active")
                 ))
             {
                 c.Emit(OpCodes.Ldarg_0);
-                c.Emit(OpCodes.Ldloc, 43);
+                c.Emit(OpCodes.Ldloc, 95);
                 c.EmitDelegate<Func<bool, Room, int, bool>>((orig, self, i) =>
                 {
                     PlacedObject obj = self.roomSettings.placedObjects[i];
@@ -1558,7 +1559,7 @@ namespace BingoMode.BingoChallenges
                 ))
             {
                 b.Emit(OpCodes.Ldarg_0);
-                b.Emit(OpCodes.Ldloc, 72);
+                b.Emit(OpCodes.Ldloc, 144);
                 b.EmitDelegate<Action<Room, WorldCoordinate>>((room, pos) =>
                 {
                     AbstractWorldEntity existingFucker = room.abstractRoom.entities.FirstOrDefault(x => x is AbstractPhysicalObject o && o.type == MSCItemType.HalcyonPearl);
@@ -1592,7 +1593,7 @@ namespace BingoMode.BingoChallenges
         {
             orig.Invoke(self, edible);
 
-            if (edible is not PhysicalObject p || p.abstractPhysicalObject.type != MSCItemType.Seed) return;
+            if (edible is not PhysicalObject p || p.abstractPhysicalObject.type != DLCItemType.Seed) return;
             for (int j = 0; j < ExpeditionData.challengeList.Count; j++)
             {
                 if (ExpeditionData.challengeList[j] is BingoSaintPopcornChallenge c)

--- a/BingoMode/BingoChallenges/ChallengeUtils.cs
+++ b/BingoMode/BingoChallenges/ChallengeUtils.cs
@@ -2,6 +2,7 @@
 using ItemType = AbstractPhysicalObject.AbstractObjectType;
 using CreatureType = CreatureTemplate.Type;
 using MSCItemType = MoreSlugcats.MoreSlugcatsEnums.AbstractObjectType;
+using DLCItemType = DLCSharedEnums.AbstractObjectType;
 using System.Collections.Generic;
 using MoreSlugcats;
 using System.Linq;
@@ -198,10 +199,10 @@ namespace BingoMode.BingoChallenges
             if (type == ItemType.WaterNut) return translator.Translate("Bubble Fruit");
             if (type == ItemType.SlimeMold) return translator.Translate("Slime Mold");
             if (type == ItemType.BubbleGrass) return translator.Translate("Bubble Grass");
-            if (type == MSCItemType.GlowWeed) return translator.Translate("Glow Weed");
-            if (type == MSCItemType.DandelionPeach) return translator.Translate("Dandelion Peaches");
-            if (type == MSCItemType.LillyPuck) return translator.Translate("Lillypucks");
-            if (type == MSCItemType.GooieDuck) return translator.Translate("Gooieducks");
+            if (type == DLCItemType.GlowWeed) return translator.Translate("Glow Weed");
+            if (type == DLCItemType.DandelionPeach) return translator.Translate("Dandelion Peaches");
+            if (type == DLCItemType.LillyPuck) return translator.Translate("Lillypucks");
+            if (type == DLCItemType.GooieDuck) return translator.Translate("Gooieducks");
 
             return orig.Invoke(type);
         }
@@ -214,7 +215,7 @@ namespace BingoMode.BingoChallenges
             creatureNames[(int)CreatureType.Hazer] = ChallengeTools.IGT.Translate("Hazers");
             creatureNames[(int)CreatureType.Salamander] = ChallengeTools.IGT.Translate("Salamanders");
             creatureNames[(int)CreatureType.Spider] = ChallengeTools.IGT.Translate("Coalescipedes");
-            if (ModManager.MSC) creatureNames[(int)MoreSlugcatsEnums.CreatureTemplateType.Yeek] = ChallengeTools.IGT.Translate("Yeeks");
+            if (ModManager.MSC) creatureNames[(int)DLCSharedEnums.CreatureTemplateType.Yeek] = ChallengeTools.IGT.Translate("Yeeks");
         }
 
         public static List<string> CreatureOriginRegions(string type, SlugcatStats.Name slug)

--- a/BingoMode/BingoMenu/BingoPage.cs
+++ b/BingoMode/BingoMenu/BingoPage.cs
@@ -1326,7 +1326,7 @@ namespace BingoMode.BingoMenu
                 if (controls)
                 {
                     conf = MenuModList.ModButton.RainWorldDummy.config.Bind<string>("_PlayerInfoSelect", TeamName(team), (ConfigAcceptableBase)null);
-                    selectTeam = new OpComboBox(conf, new Vector2(-10000f, -10000f), 90f, ["Red", "Blue", "Green", "Orange", "Pink", "Cyan", "Black", "Hurricane", "Board view"]);
+                    selectTeam = new OpComboBox(conf, new Vector2(-10000f, -10000f), 90f, new string[] { "Red", "Blue", "Green", "Orange", "Pink", "Cyan", "Black", "Hurricane", "Board view" });
                     selectTeam.OnValueChanged += SelectTeam_OnValueChanged;
                     selectTeam.OnListOpen += FocusThing;
                     selectTeam.OnListClose += UnfocusThing;

--- a/BingoMode/BingoModOptions.cs
+++ b/BingoMode/BingoModOptions.cs
@@ -60,7 +60,7 @@ namespace BingoMode
                 new OpKeyBinder(HUDKeybindC4, new Vector2(170f, 345f), new Vector2(140f, 20f), false, OpKeyBinder.BindController.Controller4),
 
                 new OpLabel(10f, 193f, "Singleplayer team color:") {alignment = FLabelAlignment.Left, description = "Which team's color to use in singleplayer"},
-                new OpComboBox(SinglePlayerTeam, new Vector2(170f, 190f), 140f, ["Red", "Blue", "Green", "Orange", "Pink", "Cyan", "Black", "Hurricane"]) {description = "Which team's color to use in singleplayer"},
+                new OpComboBox(SinglePlayerTeam, new Vector2(170f, 190f), 140f, new string[] {"Red", "Blue", "Green", "Orange", "Pink", "Cyan", "Black", "Hurricane" }) {description = "Which team's color to use in singleplayer"},
 
                 new OpLabel(430f, 512f, "Use map input instead:") {alignment = FLabelAlignment.Left},
                 new OpCheckBox(UseMapInput, 560f, 509f),

--- a/BingoMode/BingoMode.csproj
+++ b/BingoMode/BingoMode.csproj
@@ -21,7 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,11 +30,41 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="../lib/*.dll">
       <Private>false</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\lib\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-nstrip">
+      <HintPath>..\lib\Assembly-CSharp-nstrip.dll</HintPath>
+    </Reference>
+    <Reference Include="BepInEx">
+      <HintPath>..\lib\BepInEx.dll</HintPath>
+    </Reference>
+    <Reference Include="com.rlabrecque.steamworks.net">
+      <HintPath>..\lib\com.rlabrecque.steamworks.net.dll</HintPath>
+    </Reference>
+    <Reference Include="HOOKS-Assembly-CSharp">
+      <HintPath>..\lib\HOOKS-Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\lib\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod">
+      <HintPath>..\lib\MonoMod.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.RuntimeDetour">
+      <HintPath>..\lib\MonoMod.RuntimeDetour.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.Utils">
+      <HintPath>..\lib\MonoMod.Utils.dll</HintPath>
+    </Reference>
+    <Reference Include="Rewired_Core">
+      <HintPath>..\lib\Rewired_Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -45,6 +75,24 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="netstandard" />
+    <Reference Include="Unity.Mathematics">
+      <HintPath>..\lib\Unity.Mathematics.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\lib\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AudioModule">
+      <HintPath>..\lib\UnityEngine.AudioModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\lib\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>..\lib\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestWWWModule">
+      <HintPath>..\lib\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BingoBoard.cs" />
@@ -123,6 +171,6 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Rain World\RainWorld_Data\StreamingAssets\mods\bingomode\v1.9.15b\plugins\$(TargetName).dll"</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Rain World\RainWorld_Data\StreamingAssets\mods\bingomode\plugins\$(TargetName).dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/BingoMode/Plugin.cs
+++ b/BingoMode/Plugin.cs
@@ -24,7 +24,7 @@ namespace BingoMode
     [BepInPlugin("nacu.bingomode", "Bingo", VERSION)]
     public class Plugin : BaseUnityPlugin
     {
-        public const string VERSION = "1.04";
+        public const string VERSION = "1.05";
         public static bool AppliedAlreadyDontDoItAgainPlease;
         internal static ManualLogSource logger;
         private BingoModOptions _bingoConfig;


### PR DESCRIPTION
Fixed some new 1.10 constructors as well as corrected some enums. Several goals have been tested to be functional, both in singleplayer and online, though not all have been tested.
Likely further pulls with fixes for dysfunctional goals and some redundancies in ldloc calls for future patches. 