### PR TITLE
fixed possible crash when all regions are banned

### DIFF
--- a/BingoMode/BingoMenu/BingoPage.cs
+++ b/BingoMode/BingoMenu/BingoPage.cs
@@ -472,17 +472,17 @@ namespace BingoMode.BingoMenu
                     {
                         foreach (var banned in bannedRegions)
                         {
-                            if (banned == null || banned == "") continue;
-                            if (tries > 200)
+                            if (bannedRegions.Count == ChallengeUtils.GetSortedCorrectListForChallenge("regionsreal").Length)
                             {
                                 BingoData.BingoDen = "SU_S01";
-                                
-                            }
-                            if (ExpeditionData.startingDen.Substring(0, 2).ToLowerInvariant() == banned.ToLowerInvariant())
+                                ExpeditionData.startingDen = "SU_S01";
+                            } 
+                            else if (ExpeditionData.startingDen.Substring(0, 2).ToLowerInvariant() == banned.ToLowerInvariant())
                             {
                                 tries++;
                                 goto reset;
                             }
+                            if (banned == null || banned == "") continue;
                         }
                     }
                 }


### PR DESCRIPTION
I discovered that the game would crash if you made a board filled with "enter x region" squares, like this one:
https://t3sl4co1l.github.io/bingovista/bingovista.html?b=UndCaQBaBAQGHgAAAAAAHwAAAAAAVW50aXRsZWQAAA4AARQOAAEHDgABBQ4AAQYOAAESDgABFw4AARAOAAEWDgABDg4AAQIOAAERDgABCg4AAQ8OAAEMKAALFAID4AFTVV9CMTEpAAEs
, because it couldn't find an unbanned region, and the game crashed before the original check would default to SU_S01, so unless you set the spawn manually you would only ever crash. so I was like "might as well try to fix it" and it took me like 3 hours to change 5 lines so that was fun